### PR TITLE
Fix: variable error en la vista cnxbderror.blade

### DIFF
--- a/vistas/cnxbderror.blade.php
+++ b/vistas/cnxbderror.blade.php
@@ -1,4 +1,4 @@
-@extends('app', ['auth' => $auth]) 
+@extends('app', ['auth' => $error])
 @section('title') Conexion BD
 @endsection
  


### PR DESCRIPTION
La variable utilizada para mostrar el error de conexión a base de datos es incorrecta.